### PR TITLE
altered weather module to accept multiword cities

### DIFF
--- a/lib/modules/weather.rb
+++ b/lib/modules/weather.rb
@@ -28,6 +28,3 @@ class Answer
         return "I couldn't get weather information for #{cityname}."
     end
 end
-
-
-answer = Answer.new

--- a/lib/modules/weather.rb
+++ b/lib/modules/weather.rb
@@ -7,7 +7,7 @@ class Answer
     end
 
     def in # get weather for a city
-        cityname = @message.split(' ')[2].lstrip.rstrip
+        cityname = @message.split(' ')[2..-1].join('-')
 
         url = "http://api.openweathermap.org/data/2.5/weather?mode=json&units=metric&q=#{cityname}"
         response = Net::HTTP.get_response(URI.parse(url))
@@ -28,3 +28,6 @@ class Answer
         return "I couldn't get weather information for #{cityname}."
     end
 end
+
+
+answer = Answer.new


### PR DESCRIPTION
"san francisco" was entered as "san"

"san francisco" is now entered as "san-francisco" in compliance with api request url

![praise the gods of wind](http://mythmaniacs.com/BoreasandOreityiaEvelynDeMorgan.jpg)

2 commits because i forgot to remove debug nonsense
